### PR TITLE
Add support for different license types.

### DIFF
--- a/src/Locksmith.Core/Config/LicenseValidationOptions.cs
+++ b/src/Locksmith.Core/Config/LicenseValidationOptions.cs
@@ -25,4 +25,6 @@ public class LicenseValidationOptions
     /// validated during the validation process.
     /// </summary>
     public bool ValidateLicenseFields { get; set; } = true;
+
+    public bool EnforceLicenseTypeRules { get; set; } = false;
 }

--- a/src/Locksmith.Core/Enums/LicenseType.cs
+++ b/src/Locksmith.Core/Enums/LicenseType.cs
@@ -1,0 +1,11 @@
+namespace Locksmith.Core.Enums;
+
+public enum LicenseType
+{
+    Trial,
+    Full,
+    Subscription,
+    OEM,
+    Enterprise,
+    Academic
+}

--- a/src/Locksmith.Core/Models/LicenseInfo.cs
+++ b/src/Locksmith.Core/Models/LicenseInfo.cs
@@ -1,3 +1,5 @@
+using Locksmith.Core.Enums;
+
 namespace Locksmith.Core.Models;
 
 public class LicenseInfo
@@ -16,4 +18,7 @@ public class LicenseInfo
     /// The expiration date of the licence. Null means no expiration.
     /// </summary>
     public DateTime? ExpirationDate { get; set; }
+    
+    public LicenseType Type { get; set; } = LicenseType.Full;
+
 }

--- a/tests/Locksmith.Test/LicenseTypeValidationTests.cs
+++ b/tests/Locksmith.Test/LicenseTypeValidationTests.cs
@@ -1,0 +1,118 @@
+using Locksmith.Core.Enums;
+using Locksmith.Core.Models;
+using Locksmith.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Locksmith.Test;
+
+public class LicenseTypeValidationTests : TestBase
+{
+    private LicenseKeyService CreateService(bool enforceTypeRules = true)
+    {
+        var provider = BuildServiceProvider(
+            configureOptions: opts => opts.EnforceLicenseTypeRules = enforceTypeRules);
+
+        return provider.GetRequiredService<LicenseKeyService>();
+    }
+
+    private LicenseInfo CreateLicense(LicenseType type, DateTime? expiration = null)
+    {
+        return new LicenseInfo()
+        {
+            Name = "Type Test",
+            ProductId = "type-product",
+            Type = type,
+            ExpirationDate = expiration
+        };
+    }
+
+    [Fact]
+    public void Trail_License_Must_Have_Expiration()
+    {
+        var service = CreateService();
+        var license = CreateLicense(LicenseType.Trial);
+        
+        var result = service.TryGenerate(license);
+        
+        Assert.False(result.Success);
+        Assert.Equal("Trial licenses must have an expiration date.", result.Error);
+    }
+
+    [Fact]
+    public void Subscription_License_Must_Have_Expiration()
+    {
+        var service = CreateService();
+        var license = CreateLicense(LicenseType.Subscription);
+
+        var result = service.TryGenerate(license);
+        
+        Assert.False(result.Success);
+        Assert.Equal("Subscription licenses must have an expiration date.", result.Error);
+    }
+    
+    [Fact]
+    public void Full_License_Can_Be_Without_Expiration()
+    {
+        var service = CreateService();
+        var license = CreateLicense(LicenseType.Full);
+
+        var result = service.TryGenerate(license);
+        
+        Assert.True(result.Success);
+    }
+    
+    [Fact]
+    public void OEM_License_Can_Be_Without_Expiration()
+    {
+        var service = CreateService();
+        var license = CreateLicense(LicenseType.OEM);
+
+        var result = service.TryGenerate(license);
+        
+        Assert.True(result.Success);
+    }
+    
+    [Fact]
+    public void Enterprise_License_Can_Be_Without_Expiration()
+    {
+        var service = CreateService();
+        var license = CreateLicense(LicenseType.Enterprise);
+
+        var result = service.TryGenerate(license);
+        
+        Assert.True(result.Success);
+    }
+    
+    [Fact]
+    public void Academic_License_Can_Be_Without_Expiration()
+    {
+        var service = CreateService();
+        var license = CreateLicense(LicenseType.Academic);
+
+        var result = service.TryGenerate(license);
+        
+        Assert.True(result.Success);
+    }
+    
+    [Fact]
+    public void Academic_License_With_Expiration_Should_Pass()
+    {
+        var service = CreateService();
+        var license = CreateLicense(LicenseType.Academic, DateTime.UtcNow.AddDays(30));
+
+        var result = service.TryGenerate(license);
+
+        Assert.True(result.Success);
+    }
+    
+    [Fact]
+    public void Type_Rules_Should_Be_Skipped_If_Disabled()
+    {
+        var service = CreateService(enforceTypeRules: false);
+        var license = CreateLicense(LicenseType.Trial); // no expiration, but validation disabled
+
+        var result = service.TryGenerate(license);
+
+        Assert.True(result.Success);
+    }
+}


### PR DESCRIPTION
This pull request introduces several changes to enhance the license validation process in the `Locksmith.Core` project. The changes include adding a new enum for license types, updating the license validation logic to enforce rules based on license types, and adding corresponding tests to ensure the new validation rules are correctly implemented.

### Enhancements to License Validation:

* **New License Type Enum:**
  - Added `LicenseType` enum to represent different types of licenses such as Trial, Full, Subscription, OEM, Enterprise, and Academic. (`src/Locksmith.Core/Enums/LicenseType.cs`)

* **License Info Model Update:**
  - Updated `LicenseInfo` class to include a new property `Type` of type `LicenseType`, with a default value of `LicenseType.Full`. (`src/Locksmith.Core/Models/LicenseInfo.cs`)

* **Validation Logic Update:**
  - Enhanced `DefaultLicenseValidator` to include a new method `ValidateLicenseTypeRules` which enforces specific validation rules based on the license type. (`src/Locksmith.Core/Validation/DefaultLicenseValidator.cs`) [[1]](diffhunk://#diff-2f1db6d6db1213cd2b3afe69d79b4b0a35d598605ac808fc1467e36296eb12f6R37-R43) [[2]](diffhunk://#diff-2f1db6d6db1213cd2b3afe69d79b4b0a35d598605ac808fc1467e36296eb12f6R53-R86)

### Configuration and Testing:

* **Configuration Option:**
  - Added a new configuration option `EnforceLicenseTypeRules` in `LicenseValidationOptions` to enable or disable the enforcement of license type rules. (`src/Locksmith.Core/Config/LicenseValidationOptions.cs`)

* **Unit Tests:**
  - Added a comprehensive set of unit tests in `LicenseTypeValidationTests` to verify the correct enforcement of license type rules. (`tests/Locksmith.Test/LicenseTypeValidationTests.cs`)