### PR TITLE
Add License Limits

### DIFF
--- a/src/Locksmith.Core/Config/LicenseValidationOptions.cs
+++ b/src/Locksmith.Core/Config/LicenseValidationOptions.cs
@@ -46,4 +46,11 @@ public class LicenseValidationOptions
     /// include all scopes in this list to be considered valid.
     /// </summary>
     public List<string>? RequiredScopes { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether limits on license features or resources
+    /// should be enforced during validation. If set to <c>true</c>, the license will
+    /// be validated against defined limits.
+    /// </summary>
+    public bool EnforceLimitValidation { get; set; } = false;
 }

--- a/src/Locksmith.Core/DependencyInjection/LocksmithOptionsBuilder.cs
+++ b/src/Locksmith.Core/DependencyInjection/LocksmithOptionsBuilder.cs
@@ -74,5 +74,22 @@ public class LocksmithOptionsBuilder
 
         return this;
     }
-
+    
+    /// <summary>
+    /// Configures whether license limit validation should be enforced.
+    /// </summary>
+    /// <param name="enabled">
+    /// A boolean value indicating whether to enable or disable limit validation.
+    /// Defaults to <c>true</c>.
+    /// </param>
+    /// <returns>
+    /// The current <see cref="LocksmithOptionsBuilder"/> instance for method chaining.
+    /// </returns>
+    public LocksmithOptionsBuilder EnforceLimitValidation(bool enabled = true)
+    {
+        return ConfigureValidationOptions(opts =>
+        {
+            opts.EnforceLimitValidation = enabled;
+        });
+    }
 }

--- a/src/Locksmith.Core/Extensions/LicenseLimitExtensions.cs
+++ b/src/Locksmith.Core/Extensions/LicenseLimitExtensions.cs
@@ -2,8 +2,23 @@ using Locksmith.Core.Models;
 
 namespace Locksmith.Core.Extensions;
 
+/// <summary>
+/// Provides extension methods for working with license limits in the <see cref="LicenseInfo"/> class.
+/// </summary>
 public static class LicenseLimitExtensions
 {
+    /// <summary>
+    /// Determines whether the license has a specific limit defined for a given key.
+    /// </summary>
+    /// <param name="license">The license to check.</param>
+    /// <param name="key">The key representing the feature or resource to check.</param>
+    /// <param name="value">
+    /// When this method returns, contains the limit value associated with the specified key,
+    /// if the key is found; otherwise, 0.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the license has a limit defined for the specified key; otherwise, <c>false</c>.
+    /// </returns>
     public static bool HasLimit(this LicenseInfo license, string key, out int value)
     {
         value = 0;
@@ -17,6 +32,14 @@ public static class LicenseLimitExtensions
         return false;
     }
 
+    /// <summary>
+    /// Retrieves the limit value associated with a specific key in the license.
+    /// </summary>
+    /// <param name="license">The license to check.</param>
+    /// <param name="key">The key representing the feature or resource to retrieve the limit for.</param>
+    /// <returns>
+    /// The limit value associated with the specified key, or <c>null</c> if no limit is defined.
+    /// </returns>
     public static int? GetLimit(this LicenseInfo license, string key)
     {
         if (license?.Limits?.TryGetValue(key, out var val) == true)

--- a/src/Locksmith.Core/Extensions/LicenseLimitExtensions.cs
+++ b/src/Locksmith.Core/Extensions/LicenseLimitExtensions.cs
@@ -1,0 +1,27 @@
+using Locksmith.Core.Models;
+
+namespace Locksmith.Core.Extensions;
+
+public static class LicenseLimitExtensions
+{
+    public static bool HasLimit(this LicenseInfo license, string key, out int value)
+    {
+        value = 0;
+
+        if (license?.Limits != null && license.Limits.TryGetValue(key, out var found))
+        {
+            value = found;
+            return true;
+        }
+
+        return false;
+    }
+
+    public static int? GetLimit(this LicenseInfo license, string key)
+    {
+        if (license?.Limits?.TryGetValue(key, out var val) == true)
+            return val;
+
+        return null;
+    }
+}

--- a/src/Locksmith.Core/Models/LicenseInfo.cs
+++ b/src/Locksmith.Core/Models/LicenseInfo.cs
@@ -31,4 +31,11 @@ public class LicenseInfo
     /// Gets or sets the list of scopes associated with the license. A value of <c>null</c> indicates no specific scopes.
     /// </summary>
     public List<string>? Scopes { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a dictionary that defines limits for specific features or resources.
+    /// The key represents the feature/resource name, and the value represents the limit.
+    /// A value of <c>null</c> indicates no specific limits are defined.
+    /// </summary>
+    public Dictionary<string, int>? Limits { get; set; }
 }

--- a/src/Locksmith.Core/Validation/DefaultLicenseValidator.cs
+++ b/src/Locksmith.Core/Validation/DefaultLicenseValidator.cs
@@ -39,6 +39,7 @@ public class DefaultLicenseValidator : ILicenseValidator
         ValidateExpiration(licenseInfo);
         ValidateLicenseTypeRules(licenseInfo);
         ValidateLicenseScopes(licenseInfo);
+        ValidateLicenseLimits(licenseInfo);
     }
 
     /// <summary>
@@ -113,6 +114,22 @@ public class DefaultLicenseValidator : ILicenseValidator
             {
                 Handle("Required license scopes not present.");
             }
+        }
+    }
+
+    /// <summary>
+    /// Validates the license limits to ensure all defined limits are non-negative.
+    /// </summary>
+    /// <param name="licenseInfo">The license information to validate.</param>
+    /// <exception cref="LicenseValidationException">
+    /// Thrown if any limit value is negative.
+    /// </exception>
+    private void ValidateLicenseLimits(LicenseInfo licenseInfo)
+    {
+        if (_options.EnforceLimitValidation)
+        {
+            if (licenseInfo.Limits?.Any(kv => kv.Value < 0) == true)
+                throw new LicenseValidationException("Limit values must be non-negative.");
         }
     }
 

--- a/tests/Locksmith.Test/LicenseUsageLimitTests.cs
+++ b/tests/Locksmith.Test/LicenseUsageLimitTests.cs
@@ -1,0 +1,100 @@
+using Locksmith.Core.Extensions;
+using Locksmith.Core.Models;
+
+namespace Locksmith.Test;
+
+public class LicenseUsageLimitTests : TestBase
+{
+    private LicenseInfo CreateLicense(Dictionary<string, int>? limits = null)
+    {
+        return new LicenseInfo
+        {
+            Name = "Usage Test",
+            ProductId = "usage.test",
+            ExpirationDate = DateTime.Now.AddDays(10),
+            Limits = limits
+        };
+    }
+
+    [Fact]
+    public void HasLimit_Should_Return_True_When_Limit_Is_Defined()
+    {
+        var license = CreateLicense(
+            new Dictionary<string, int>
+            {
+                {
+                    "MaxUsers", 10
+                }
+            });
+
+        Assert.True(license.HasLimit("MaxUsers", out var val));
+        Assert.Equal(10, val);
+    }
+
+    [Fact]
+    public void HasLimit_Should_Return_False_When_Limit_Is_Not_Defined()
+    {
+        var license = CreateLicense(
+            new Dictionary<string, int>
+            {
+                {
+                    "MaxUsers", 10
+                }
+            });
+        
+        Assert.False(license.HasLimit("MaxProjects", out _));
+    }
+
+    [Fact]
+    public void GetLimit_Should_Return_Value_When_Limit_Exits()
+    {
+        var license = CreateLicense(
+            new Dictionary<string, int>
+            {
+                {
+                    "MaxDevices", 5
+                }
+            });
+        
+        Assert.Equal(5, license.GetLimit("MaxDevices"));
+    }
+
+    [Fact]
+    public void GetLimit_Should_Return_Null_When_Limit_Not_Exist()
+    {
+        var license = CreateLicense(
+            new Dictionary<string, int>
+            {
+                {
+                    "MaxDevices", 5
+                }
+            });
+        
+        Assert.Null(license.GetLimit("Nonexistent"));
+    }
+
+    [Fact]
+    public void GetLimit_Should_Handle_Null_Limits_Gracefully()
+    {
+        var license = CreateLicense(null);
+        Assert.Null(license.GetLimit("Any"));
+    }
+
+    [Fact]
+    public void HasLimit_Should_Handle_Null_License_Gracefully()
+    {
+        LicenseInfo? license = null;
+        Assert.False(license.HasLimit("Any", out _));
+    }
+    
+    [Fact]
+    public void HasLimit_Should_Handle_Null_Limits_Gracefully()
+    {
+        var license = new LicenseInfo
+        {
+            Limits = null
+        };
+        
+        Assert.False(license.HasLimit("Any", out _));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for license limit validation, including changes to the core library and associated tests. The main updates include adding support for defining and validating license limits, extending the `LicenseInfo` model, and providing utility methods for working with license limits.

### Enhancements to license validation:

* **License limit enforcement option**: Added a new property `EnforceLimitValidation` to `LicenseValidationOptions` to enable or disable license limit validation during the validation process.  
* **Validation logic for license limits**: Introduced the `ValidateLicenseLimits` method in `DefaultLicenseValidator` to ensure all defined license limits are non-negative. This method is invoked as part of the overall license validation process. [[1]](diffhunk://#diff-2f1db6d6db1213cd2b3afe69d79b4b0a35d598605ac808fc1467e36296eb12f6R42) [[2]](diffhunk://#diff-2f1db6d6db1213cd2b3afe69d79b4b0a35d598605ac808fc1467e36296eb12f6R120-R135)

### Extensions and utilities for license limits:

* **Utility methods for limits**: Added the `LicenseLimitExtensions` class with methods `HasLimit` and `GetLimit` for checking and retrieving license limits in a safe and reusable way.

### Updates to models and configuration:

* **LicenseInfo model update**: Added a `Limits` property to the `LicenseInfo` class to define a dictionary of feature/resource limits.  
* **Builder method for limit enforcement**: Added the `EnforceLimitValidation` method to `LocksmithOptionsBuilder` for configuring the `EnforceLimitValidation` option in a fluent API style.

### Unit tests for license limits:

* **Comprehensive test coverage**: Added `LicenseUsageLimitTests` to validate the behavior of `HasLimit` and `GetLimit` methods, including edge cases such as null limits or undefined keys.