### PR TITLE
Add License Metadata support

### DIFF
--- a/src/Locksmith.Core/Extensions/LicenseMetadataExtensions.cs
+++ b/src/Locksmith.Core/Extensions/LicenseMetadataExtensions.cs
@@ -1,0 +1,38 @@
+using Locksmith.Core.Models;
+
+namespace Locksmith.Core.Extensions;
+
+/// <summary>
+/// Provides extension methods for working with metadata in the <see cref="LicenseInfo"/> class.
+/// </summary>
+public static class LicenseMetadataExtensions
+{
+    /// <summary>
+    /// Retrieves the metadata value associated with a specific key in the license.
+    /// </summary>
+    /// <param name="license">The license to check.</param>
+    /// <param name="key">The key representing the metadata field to retrieve.</param>
+    /// <returns>
+    /// The metadata value associated with the specified key, or <c>null</c> if the key is not found.
+    /// </returns>
+    public static string? GetMetadata(this LicenseInfo license, string key)
+    {
+        if (license?.Metadata != null && license.Metadata.TryGetValue(key, out var value))
+            return value;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determines whether the license contains a specific metadata key.
+    /// </summary>
+    /// <param name="license">The license to check.</param>
+    /// <param name="key">The key representing the metadata field to check for.</param>
+    /// <returns>
+    /// <c>true</c> if the metadata key exists in the license; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool HasMetadata(this LicenseInfo license, string key)
+    {
+        return license?.Metadata?.ContainsKey(key) == true;
+    }
+}

--- a/src/Locksmith.Core/Models/LicenseInfo.cs
+++ b/src/Locksmith.Core/Models/LicenseInfo.cs
@@ -38,4 +38,11 @@ public class LicenseInfo
     /// A value of <c>null</c> indicates no specific limits are defined.
     /// </summary>
     public Dictionary<string, int>? Limits { get; set; }
+
+    /// <summary>
+    /// Gets or sets a dictionary that contains metadata associated with the license.
+    /// The key represents the metadata field name, and the value represents the field value.
+    /// A value of <c>null</c> indicates no metadata is defined.
+    /// </summary>
+    public Dictionary<string, string>? Metadata { get; set; }
 }

--- a/tests/Locksmith.Test/LicenseMetadataTests.cs
+++ b/tests/Locksmith.Test/LicenseMetadataTests.cs
@@ -1,0 +1,83 @@
+using Locksmith.Core.Extensions;
+using Locksmith.Core.Models;
+
+namespace Locksmith.Test;
+
+public class LicenseMetadataTests : TestBase
+{
+    private LicenseInfo CreateLicense(Dictionary<string, string> metadata = null)
+    {
+        return new LicenseInfo
+        {
+            Name = "Metadata User",
+            ProductId = "metadata.product",
+            ExpirationDate = DateTime.Now.AddDays(10),
+            Metadata = metadata
+        };
+    }
+
+    [Fact]
+    public void GetMetadata_Should_Return_Correct_Value_If_Key_Exists()
+    {
+        var license = CreateLicense(new Dictionary<string, string>
+        {
+            { "Region", "EU" },
+            { "TenantId", "acme" }
+        });
+        
+        Assert.Equal("EU", license.GetMetadata("Region"));
+        Assert.Equal("acme", license.GetMetadata("TenantId"));
+    }
+
+    [Fact]
+    public void GetMetadata_Should_Return_Null_If_Key_Not_Found()
+    {
+        var license = CreateLicense(
+            new Dictionary<string, string>
+            {
+                { "Environment", "prod" }
+            });
+        
+        Assert.Null(license.GetMetadata("MissingKey"));
+    }
+
+    [Fact]
+    public void HasMetadata_Should_Return_True_If_Key_Exists()
+    {
+        var license = CreateLicense(
+            new Dictionary<string, string>
+            {
+                { "IssuedBy", "admin" }
+            });
+        
+        Assert.True(license.HasMetadata("IssuedBy"));
+    }
+    
+    [Fact]
+    public void HasMetadata_Should_Return_False_If_Key_Not_Exists()
+    {
+        var license = CreateLicense(new Dictionary<string, string>());
+        Assert.False(license.HasMetadata("NotThere"));
+    }
+
+    [Fact]
+    public void GetMetadata_Should_Handle_Null_Metadata_Gracefully()
+    {
+        var license = CreateLicense(null);
+        Assert.Null(license.GetMetadata("Anything"));
+    }
+
+    [Fact]
+    public void HasMetadata_Should_Handle_Null_Metadata_Gracefully()
+    {
+        var license = CreateLicense(null);
+        Assert.False(license.HasMetadata("Missing"));
+    }
+
+    [Fact]
+    public void HasMetadata_Should_Handle_Null_License_Gracefully()
+    {
+        LicenseInfo? license = null;
+        Assert.False(license.HasMetadata("TenantId"));
+    }
+}


### PR DESCRIPTION
This pull request introduces functionality for managing metadata in the `LicenseInfo` class, including new extension methods and corresponding unit tests. The most important changes are the addition of metadata support in the `LicenseInfo` model, new extension methods for accessing and checking metadata, and comprehensive unit tests to validate the new functionality.

### Metadata Support in `LicenseInfo`:

* Added a `Metadata` property to the `LicenseInfo` class, which is a nullable dictionary for storing metadata fields and their values. This enables licenses to hold additional key-value pairs of information.

### Extension Methods for Metadata:

* Introduced `GetMetadata` and `HasMetadata` extension methods in the new `LicenseMetadataExtensions` class. These methods provide an easy way to retrieve metadata values and check for the existence of metadata keys.

### Unit Tests for Metadata Functionality:

* Added `LicenseMetadataTests` class to validate the behavior of the `GetMetadata` and `HasMetadata` methods. Tests cover scenarios including key existence, missing keys, null metadata, and null licenses to ensure robustness.