### PR TITLE
Add License Revocation

### DIFF
--- a/src/Locksmith.Core/Extensions/LocksmithOptionsBuilderExtensions.cs
+++ b/src/Locksmith.Core/Extensions/LocksmithOptionsBuilderExtensions.cs
@@ -1,0 +1,21 @@
+using Locksmith.Core.DependencyInjection;
+using Locksmith.Core.Security;
+
+namespace Locksmith.Core.Extensions;
+
+/// <summary>
+/// Provides extension methods for configuring the <see cref="LocksmithOptionsBuilder"/>.
+/// </summary>
+public static class LocksmithOptionsBuilderExtensions
+{
+    /// <summary>
+    /// Configures the <see cref="LocksmithOptionsBuilder"/> to use a test secret for license security.
+    /// </summary>
+    /// <param name="builder">The <see cref="LocksmithOptionsBuilder"/> to configure.</param>
+    /// <param name="secret">The test secret to use. Defaults to "test-secret".</param>
+    /// <returns>The configured <see cref="LocksmithOptionsBuilder"/> instance.</returns>
+    public static LocksmithOptionsBuilder UseTestSecret(this LocksmithOptionsBuilder builder, string secret = "test-secret")
+    {
+        return builder.UseSecretProvider(new InMemoryRotatingSecretProvider(secret));
+    }
+}

--- a/src/Locksmith.Core/Models/LicenseInfo.cs
+++ b/src/Locksmith.Core/Models/LicenseInfo.cs
@@ -8,6 +8,12 @@ namespace Locksmith.Core.Models;
 public class LicenseInfo
 {
     /// <summary>
+    /// Gets or sets the unique identifier for the license.
+    /// Defaults to a new GUID when the object is instantiated.
+    /// </summary>
+    public Guid LicenseId { get; set; } = Guid.NewGuid();
+    
+    /// <summary>
     /// Gets or sets the name of the license holder (e.g., individual or organization).
     /// </summary>
     public string Name { get; set; }

--- a/src/Locksmith.Core/Revocation/ILicenseRevocationProvider.cs
+++ b/src/Locksmith.Core/Revocation/ILicenseRevocationProvider.cs
@@ -1,0 +1,8 @@
+using Locksmith.Core.Models;
+
+namespace Locksmith.Core.Revocation;
+
+public interface ILicenseRevocationProvider
+{
+    bool IsRevoked(LicenseInfo licenseInfo);
+}

--- a/src/Locksmith.Core/Revocation/ListRevocationProvider.cs
+++ b/src/Locksmith.Core/Revocation/ListRevocationProvider.cs
@@ -1,0 +1,18 @@
+using Locksmith.Core.Models;
+
+namespace Locksmith.Core.Revocation;
+
+public class ListRevocationProvider : ILicenseRevocationProvider
+{
+    private readonly HashSet<Guid> _revokedIds;
+
+    public ListRevocationProvider(IEnumerable<Guid> revokedLicenseIds)
+    {
+        _revokedIds = new HashSet<Guid>(revokedLicenseIds);
+    }
+
+    public bool IsRevoked(LicenseInfo licenseInfo)
+    {
+        return licenseInfo != null && _revokedIds.Contains(licenseInfo.LicenseId);
+    }
+}

--- a/tests/Locksmith.Test/LicenseRevocationTests.cs
+++ b/tests/Locksmith.Test/LicenseRevocationTests.cs
@@ -1,0 +1,81 @@
+using Locksmith.Core.Models;
+using Locksmith.Core.Revocation;
+using Locksmith.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Locksmith.Test;
+
+public class LicenseRevocationTests : TestBase
+{
+    private LicenseKeyService CreateService(IEnumerable<Guid> revokedIds)
+    {
+        var service = BuildServiceProvider(
+            overrideSecretProvider: CreateFakeSecretProvider(),
+            configureOptions: options =>
+            {
+                options.ValidateLicenseFields = false;
+                options.ThrowOnValidationError = false;
+            },
+            overrideRevocationProvider: new ListRevocationProvider(revokedIds)
+        );
+
+        return service.GetRequiredService<LicenseKeyService>();
+    }
+
+    private LicenseInfo CreateLicense(out Guid licenseId)
+    {
+        var license = new LicenseInfo
+        {
+            Name = "Revoked User",
+            ProductId = "revoked-product",
+            ExpirationDate = DateTime.UtcNow.AddDays(5)
+        };
+
+        licenseId = license.LicenseId;
+        return license;
+    }
+
+    [Fact]
+    public void Validate_Should_Fail_When_License_Is_Revoked()
+    {
+        var license = CreateLicense(out var licenseId);
+        var service = CreateService(new[] { licenseId });
+
+        var key = service.Generate(license);
+        var result = service.Validate(key);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("License has been revoked.", result.Error);
+    }
+
+    [Fact]
+    public void Validate_Should_Succeed_When_License_Is_Not_Revoked()
+    {
+        var license = CreateLicense(out var licenseId);
+        var service = CreateService(new[] { Guid.NewGuid() }); // unrelated revoked ID
+
+        var key = service.Generate(license);
+        var result = service.Validate(key);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(licenseId, result.LicenseInfo.LicenseId);
+    }
+
+    [Fact]
+    public void Validate_Should_Succeed_When_RevocationProvider_Is_Not_Used()
+    {
+        var license = CreateLicense(out var licenseId);
+
+        var provider = BuildServiceProvider(
+            overrideSecretProvider: CreateFakeSecretProvider(),
+            configureOptions: opts => opts.ValidateLicenseFields = false);
+
+        var service = provider.GetRequiredService<LicenseKeyService>();
+
+        var key = service.Generate(license);
+        var result = service.Validate(key);
+
+        Assert.True(result.IsValid);
+    }
+}


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `Locksmith` library, focusing on license revocation support, improved configurability, and testing. Key updates include adding a license revocation system, extending the `LocksmithOptionsBuilder` with new configuration options, and updating the `LicenseKeyService` to handle revocation checks. Additionally, new tests ensure the correctness of these changes.

### License Revocation System:
* Added `ILicenseRevocationProvider` interface to define the contract for license revocation checks (`src/Locksmith.Core/Revocation/ILicenseRevocationProvider.cs`).
* Implemented `ListRevocationProvider`, a concrete revocation provider using a list of revoked license IDs (`src/Locksmith.Core/Revocation/ListRevocationProvider.cs`).
* Updated `LicenseKeyService` to integrate revocation checks during license validation (`src/Locksmith.Core/Services/LicenseKeyService.cs`). [[1]](diffhunk://#diff-4b0a232587abfac71cd5eb5cb42015f20a2ab1846a3301408b673a1117953fd7R26-R44) [[2]](diffhunk://#diff-4b0a232587abfac71cd5eb5cb42015f20a2ab1846a3301408b673a1117953fd7R128-R132)

### Configuration Enhancements:
* Added new methods to `LocksmithOptionsBuilder` for configuring a license validator and a revocation provider (`src/Locksmith.Core/DependencyInjection/LocksmithOptionsBuilder.cs`). [[1]](diffhunk://#diff-e3783fa16daec6e6158343c3b9b7287bc545d3e186388e537043ee5c608ae08dL20-R43) [[2]](diffhunk://#diff-e3783fa16daec6e6158343c3b9b7287bc545d3e186388e537043ee5c608ae08dL41-R99)
* Updated `LocksmithServiceCollectionExtensions` to enforce the configuration of a secret provider and optionally include a revocation provider (`src/Locksmith.Core/DependencyInjection/LocksmithServiceCollectionExtensions.cs`).
* Introduced an extension method `UseTestSecret` for simplified test configuration (`src/Locksmith.Core/Extensions/LocksmithOptionsBuilderExtensions.cs`).

### License Model Update:
* Added a `LicenseId` property to the `LicenseInfo` model to uniquely identify licenses (`src/Locksmith.Core/Models/LicenseInfo.cs`).

### Testing:
* Created `LicenseRevocationTests` to validate the behavior of license revocation, including scenarios for revoked and non-revoked licenses (`tests/Locksmith.Test/LicenseRevocationTests.cs`).
* Enhanced the `TestBase` class to support overriding the revocation provider during test setup (`tests/Locksmith.Test/TestBase.cs`). [[1]](diffhunk://#diff-c81bd70f2a9d832a7c32775c71be930d59279c0b6d9fad6afdb18f3d5ff2f315L23-R25) [[2]](diffhunk://#diff-c81bd70f2a9d832a7c32775c71be930d59279c0b6d9fad6afdb18f3d5ff2f315R60-R64)