### PR TITLE
Update Test & Build CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build-test:
     name: Build & Test (.NET 9)
@@ -35,71 +39,20 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Check formatting
-        id: format
-        run: |
-          dotnet format --verify-no-changes --verbosity diagnostic > format-results.txt || echo "FORMAT_ERROR=true" >> $GITHUB_ENV
-
-      - name: Upload format results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: format-results
-          path: format-results.txt
-
-      - name: Comment on PR if formatting failed
-        if: env.FORMAT_ERROR == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const results = fs.readFileSync('format-results.txt', 'utf8');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🛑 **Code formatting check failed**.\n\nPlease run \`dotnet format\` locally and commit the changes.\n\n\`\`\`\n${results.slice(0, 3000)}\n\`\`\`\n_Only first 3000 characters shown._`
-            });
-
-      - name: Fail if formatting failed
-        if: env.FORMAT_ERROR == 'true'
-        run: exit 1
-
       - name: Build solution
         run: dotnet build --no-restore --configuration Release --verbosity minimal
 
       - name: Run tests
-        run: dotnet test --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test_results.trx" > test-results.txt || echo "TEST_ERROR=true" >> $GITHUB_ENV
-
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: '**/TestResults/*.trx'
+        run: |
+          mkdir -p ./TestResults
+          dotnet test --no-build --configuration Release --verbosity normal \
+            --logger "trx;LogFileName=test_results.trx" \
+            --results-directory ./TestResults
 
       - name: Annotate test results
         if: always()
         uses: dorny/test-reporter@v1
         with:
           name: .NET Tests
-          path: '**/TestResults/*.trx'
+          path: ./TestResults/*.trx
           reporter: dotnet-trx
-
-      - name: Comment on PR if tests failed
-        if: env.TEST_ERROR == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const results = fs.readFileSync('test-results.txt', 'utf8');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `❌ **Tests failed** during CI run.\n\n\`\`\`\n${results.slice(0, 3000)}\n\`\`\`\n_Only first 3000 characters shown._`
-            });
-
-      - name: Fail if tests failed
-        if: env.TEST_ERROR == 'true'
-        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  checks: write
 
 jobs:
   build-test:
@@ -50,7 +51,7 @@ jobs:
             --results-directory ./TestResults
 
       - name: Annotate test results
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: dorny/test-reporter@v1
         with:
           name: .NET Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,105 @@
 name: Build & Test
 
 on:
-  push:
-    branches: [ "*" ]
   pull_request:
-    branches: [ "*" ]
+    branches: [ "main" ]
 
 jobs:
   build-test:
-    name: Build & Test (.NET 8/9)
+    name: Build & Test (.NET 9)
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: true
       matrix:
         dotnet-version: [ '9.0.x' ]
 
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup .NET ${{ matrix.dotnet-version }}
+      - name: Setup .NET SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ matrix.dotnet-version }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ matrix.dotnet-version }}-
+            nuget-${{ runner.os }}-
+
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Build
-        run: dotnet build --no-restore --configuration Release
+      - name: Check formatting
+        id: format
+        run: |
+          dotnet format --verify-no-changes --verbosity diagnostic > format-results.txt || echo "FORMAT_ERROR=true" >> $GITHUB_ENV
 
-      - name: Run Tests
-        run: dotnet test --no-build --verbosity normal --configuration Release
+      - name: Upload format results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: format-results
+          path: format-results.txt
+
+      - name: Comment on PR if formatting failed
+        if: env.FORMAT_ERROR == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('format-results.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🛑 **Code formatting check failed**.\n\nPlease run \`dotnet format\` locally and commit the changes.\n\n\`\`\`\n${results.slice(0, 3000)}\n\`\`\`\n_Only first 3000 characters shown._`
+            });
+
+      - name: Fail if formatting failed
+        if: env.FORMAT_ERROR == 'true'
+        run: exit 1
+
+      - name: Build solution
+        run: dotnet build --no-restore --configuration Release --verbosity minimal
+
+      - name: Run tests
+        run: dotnet test --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test_results.trx" > test-results.txt || echo "TEST_ERROR=true" >> $GITHUB_ENV
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/TestResults/*.trx'
+
+      - name: Annotate test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: .NET Tests
+          path: '**/TestResults/*.trx'
+          reporter: dotnet-trx
+
+      - name: Comment on PR if tests failed
+        if: env.TEST_ERROR == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('test-results.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ **Tests failed** during CI run.\n\n\`\`\`\n${results.slice(0, 3000)}\n\`\`\`\n_Only first 3000 characters shown._`
+            });
+
+      - name: Fail if tests failed
+        if: env.TEST_ERROR == 'true'
+        run: exit 1


### PR DESCRIPTION
This pull request updates the `.github/workflows/ci.yml` file to refine the CI workflow for .NET projects. The changes focus on improving efficiency, enhancing test result reporting, and aligning the workflow configuration with best practices.

### Workflow Configuration Updates:

* Restricted the workflow to trigger only on `main` branch pull requests, instead of all branches. Added permissions for `contents`, `pull-requests`, and `checks` to improve security and functionality.
* Updated the job name to `Build & Test (.NET 9)` and removed support for .NET 8, focusing exclusively on .NET 9.

### Efficiency Improvements:

* Enabled NuGet package caching to reduce build times by reusing previously downloaded dependencies.
* Added the `fail-fast` strategy to terminate the workflow early if one matrix job fails.

